### PR TITLE
docs: Fulfill requirements of uPortal Ecosystem intake process

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,7 @@
+This project ( `soffit-kotlin-example`) defines its committers by reference.
+
+The committers for this project are those for uPortal itself, documented
+as of this writing in [`COMMITTERS.md` in `Jasig/uPortal`][uPortal committers].
+
+
+[uPortal committers]: https://github.com/Jasig/uPortal/blob/master/docs/COMMITTERS.md

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ A simple soffit written with Spring 5, Gradle, and Kotlin.
 ## Start
 
 From a terminal to the *soffit-kotlin-example* folder, run `./gradlew bootRun` or `gradlew.bat bootRun`
+
+## uPortal Contrib
+
+For purposes of this project's participation in uPortal's 
+[uPortal Ecosystem Intake Process][],
+the "Project Lead" is (uPortal Committer) Christian Murphy.
+
+[uPortal Ecosystem Intake Process]: https://docs.google.com/document/d/18iG8oAPaADzgrk4JMok_Byg0DiPmuNS9S8RRdzSF0nQ/edit


### PR DESCRIPTION
The [uPortal Ecosystem Intake Process](https://docs.google.com/document/d/18iG8oAPaADzgrk4JMok_Byg0DiPmuNS9S8RRdzSF0nQ/edit) requires of projects for intake into `uPortal-contrib`:

> ...
> + A proposed Project Lead with contact information
> + A list of the initial committers for the Project...
> 
> ...

Fulfills these requirements by documenting a project lead (drafting Christian Murphy for this role) and adopting the uPortal committers by reference.